### PR TITLE
Add TaxEvidence::retrieve() method

### DIFF
--- a/lib/TaxEvidence.php
+++ b/lib/TaxEvidence.php
@@ -27,6 +27,7 @@ namespace Octobat;
 class TaxEvidence extends ApiResource
 {
     use ApiOperations\Create;
+    use ApiOperations\Retrieve;
 
 
 }


### PR DESCRIPTION
It seems this works without problems, and actually matches API documentation. Is it okay to accept this?﻿
